### PR TITLE
Comments

### DIFF
--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -31,5 +31,5 @@
         </div>
 </div>
 
-
+// Comments below!
 


### PR DESCRIPTION
I noticed that the login and register links in the navbar still appear on the main books.ejs page where all the books are displayed after logging in. I think it would be great if you hid these links in the narbar once you're logged into the site and add in a logout button instead that will reroute back to the landing page.